### PR TITLE
Make docker compose cmd customizable

### DIFF
--- a/saritasa_invocations/_config.py
+++ b/saritasa_invocations/_config.py
@@ -45,6 +45,7 @@ class PythonSettings:
 class DockerSettings:
     """Settings for docker module."""
 
+    compose_cmd = "docker compose"
     main_containers: collections.abc.Sequence[str] = (
         "postgres",
         "redis",


### PR DESCRIPTION
Reason: depending on cmd and environment different versions of docker-compose could be used. For example in GitHub actions: `docker-compose` -> v1 and `docker compose` -> v2