### PR TITLE
Fix k8s errors for multiple app pods

### DIFF
--- a/saritasa_invocations/_config.py
+++ b/saritasa_invocations/_config.py
@@ -180,7 +180,7 @@ class K8SDBSettings:
     pod_command: str = (
         "kubectl get pods --namespace {db_pod_namespace} "
         "--selector={db_pod_selector} "
-        "--output jsonpath='{{.items[*].metadata.name}}'"
+        "--output jsonpath='{{.items[0].metadata.name}}'"
     )
     exec_command: str = (
         "kubectl exec -ti --namespace {db_pod_namespace} " "$({db_pod})"

--- a/saritasa_invocations/k8s.py
+++ b/saritasa_invocations/k8s.py
@@ -75,7 +75,7 @@ def get_pod_cmd(
     return (
         "kubectl get pods"
         f" --selector {config.pod_label}={component}"
-        " --no-headers --output jsonpath='{.items[*].metadata.name}'"
+        " --no-headers --output jsonpath='{.items[0].metadata.name}'"
     )
 
 


### PR DESCRIPTION
### Description

It's often case that environments have 2 application pods. Example:

![image](https://github.com/saritasa-nest/saritasa-python-invocations/assets/38659383/c168920d-c623-4d1c-a982-09070aeb2ebe)

And if we run `inv k8s.logs` we got the following error:

![image](https://github.com/saritasa-nest/saritasa-python-invocations/assets/38659383/bdf12d3f-289d-40bf-bc21-4b357520d59c)


Similar problem with for dumping remote DB:

![image](https://github.com/saritasa-nest/saritasa-python-invocations/assets/38659383/04ef5bf7-9406-4587-ae01-2785282bd242)



So I changed `k8s` so that `first` pod (with index 0) is always selected

### Note:
For single app pod it's works too
