### PR TITLE
Add `docker.pull` command for docker invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ We follow [Semantic Versions](https://semver.org/).
 
 ## unreleased
 
+- Add `docker.pull` command to docker invocations
+
 ## 0.8.2
 
 - Hotfix context override

--- a/README.md
+++ b/README.md
@@ -284,6 +284,14 @@ Settings:
 
 Shortcut for stopping ALL running docker containers
 
+#### docker.pull
+
+Pull images associated with main containers.
+
+Settings:
+
+* `pull_params` params for docker pull command (Default: `--quiet`)
+
 #### docker.up
 
 Bring up main containers and start them.

--- a/saritasa_invocations/_config.py
+++ b/saritasa_invocations/_config.py
@@ -64,6 +64,7 @@ class DockerSettings:
     """Settings for docker module."""
 
     compose_cmd = "docker compose"
+    pull_params = "--quiet"
     main_containers: collections.abc.Sequence[str] = (
         "postgres",
         "redis",

--- a/saritasa_invocations/docker.py
+++ b/saritasa_invocations/docker.py
@@ -147,6 +147,37 @@ def stop_containers(
     context.run(f"{compose_cmd} stop {' '.join(containers)}")
 
 
+def pull_images(
+    context: invoke.Context,
+    services: collections.abc.Sequence[str],
+) -> None:
+    """Pull docker images to bring up containers."""
+    config = _config.Config.from_context(context)
+    if services:
+        printing.print_success(
+            f"Pulling images associated with services {', '.join(services)}",
+        )
+    else:
+        printing.print_success("Pulling all images")
+    services_str = " ".join(services)
+    compose_cmd = config.docker.compose_cmd
+    pull_params = config.docker.pull_params
+    pull_cmd = f"{compose_cmd} pull {pull_params} {services_str}"
+    context.run(pull_cmd)
+
+
+@invoke.task
+def pull(context: invoke.Context) -> None:
+    """Pull images associated with main containers."""
+    config = _config.Config.from_context(context)
+    if not config.docker.main_containers:
+        return
+    pull_images(
+        context,
+        services=config.docker.main_containers,
+    )
+
+
 @invoke.task
 def up(context: invoke.Context) -> None:
     """Bring up main containers and start them."""


### PR DESCRIPTION
### Motivation:

* Reduce docker output during application startup (Especially on CI)